### PR TITLE
Update Zend\Version reference to Zend\Version\Version

### DIFF
--- a/src/ZFTool/Controller/InfoController.php
+++ b/src/ZFTool/Controller/InfoController.php
@@ -5,7 +5,7 @@ namespace ZFTool\Controller;
 use Zend\Mvc\Controller\AbstractActionController;
 use Zend\View\Model\ViewModel;
 use Zend\Stdlib\ArrayUtils;
-use Zend\Version;
+use Zend\Version\Version;
 
 
 class InfoController extends AbstractActionController


### PR DESCRIPTION
When I run `php public/index.php version` from a ZendSkeletonApplication with ZFTool installed I get the following exception:

```
PHP Fatal error:  Class 'Zend\Version' not found in /var/www/ZendSkeletonApplication/vendor/ZFTool/src/ZFTool/Controller/InfoController.php on line 15
```
