### PR TITLE
Fixing config path so it works after class move.

### DIFF
--- a/src/ZFTool/Module.php
+++ b/src/ZFTool/Module.php
@@ -30,7 +30,7 @@ class Module implements ConsoleUsageProviderInterface, AutoloaderProviderInterfa
         return array(
             'Zend\Loader\StandardAutoloader' => array(
                 'namespaces' => array(
-                    __NAMESPACE__ => __DIR__ . '/src/' . __NAMESPACE__,
+                    __NAMESPACE__ => __DIR__,
                 ),
             ),
         );


### PR DESCRIPTION
With the move of the Module class, the config path was no longer valid. This fixes it up :)
