### PR TITLE
Added the ZF library install feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,10 +41,10 @@ It runs from the command line and can be installed as ZF2 module or as PHAR (see
 
 ### Module creation
 
-    zf-php create module <name> [path]
+    zf.php create module <name> [<path>]
 
     <name>              The name of the module to be created
-    path                The path to the root folder of the ZF2 application (optional)
+    <path>              The path to the root folder of the ZF2 application (optional)
 
 ### Classmap generator
 
@@ -55,6 +55,13 @@ It runs from the command line and can be installed as ZF2 module or as PHAR (see
                         autoload_classmap.php inside <directory>.
     --append | -a       Append to classmap file if it exists
     --overwrite | -w    Whether or not to overwrite existing classmap file
+
+### ZF library installation
+
+    zf.php install zf <path> [<version>]
+
+    <path>              The directory where to install the ZF2 library
+    <version>           The version to install, if not specified uses the last available
 
 ### Compile the PHAR file
 

--- a/config/module.config.php
+++ b/config/module.config.php
@@ -18,6 +18,7 @@ return array(
             'ZFTool\Controller\Module'   => 'ZFTool\Controller\ModuleController',
             'ZFTool\Controller\Classmap' => 'ZFTool\Controller\ClassmapController',
             'ZFTool\Controller\Create'   => 'ZFTool\Controller\CreateController',
+            'ZFTool\Controller\Install'  => 'ZFTool\Controller\InstallController',
         ),
     ),
 
@@ -84,6 +85,15 @@ return array(
                         'defaults' => array(
                             'controller' => 'ZFTool\Controller\Create',
                             'action'     => 'module',
+                        ),
+                    ),
+                ),
+                'zftool-install-zf' => array(
+                    'options' => array(
+                        'route'    => 'install zf <path> [<version>]',
+                        'defaults' => array(
+                            'controller' => 'ZFTool\Controller\Install',
+                            'action'     => 'zf',
                         ),
                     ),
                 ),

--- a/src/ZFTool/Controller/CreateController.php
+++ b/src/ZFTool/Controller/CreateController.php
@@ -50,10 +50,10 @@ class CreateController extends AbstractActionController
        
         $zip = new \ZipArchive;
         if ($zip->open($tmpFile)) { 
+            $tmpSkeleton = $tmpDir . '/' . rtrim($zip->statIndex(0)['name'], "/"); 
             if (!$zip->extractTo($tmpDir)) {
                 return $this->sendError("Error during the unzip of $tmpFile.");
             }
-            $tmpSkeleton = $tmpDir . '/' . Skeleton::SKELETON_DIR;
             $result = Utility::copyFiles($tmpSkeleton, $path);
             if (file_exists($tmpSkeleton)) {
                 Utility::deleteFolder($tmpSkeleton);

--- a/src/ZFTool/Controller/InstallController.php
+++ b/src/ZFTool/Controller/InstallController.php
@@ -1,0 +1,89 @@
+<?php
+
+namespace ZFTool\Controller;
+
+use Zend\Mvc\Controller\AbstractActionController;
+use Zend\View\Model\ViewModel;
+use Zend\View\Model\ConsoleModel;
+use ZFTool\Model\Zf;
+use ZFTool\Model\Utility;
+use Zend\Console\ColorInterface as Color;
+
+class InstallController extends AbstractActionController
+{
+    
+    public function zfAction()
+    {        
+        if (!extension_loaded('zip')) {
+            return $this->sendError('You need to install the ZIP extension of PHP');
+        }
+        $console = $this->getServiceLocator()->get('console');
+        $tmpDir  = sys_get_temp_dir();
+        $request = $this->getRequest();
+        $version = $request->getParam('version');
+        $path    = rtrim($request->getParam('path'), '/');
+                
+        if (file_exists($path)) {
+            return $this->sendError (
+                "The directory $path already exists. You cannot install the ZF2 library here."
+            );
+        }
+        
+        if (empty($version)) {
+            $version = Zf::getLastVersion();
+            if (false === $version) {
+                return $this->sendError (
+                    "I cannot connect to the Zend Framework website."
+                );
+            }
+        } else {
+            if (!Zf::checkVersion($version)) {
+                return $this->sendError (
+                    "The specified ZF version, $version, doesn't exist."
+                );
+            }
+        }
+        
+        $tmpFile = ZF::getTmpFileName($tmpDir, $version);
+        if (!file_exists($tmpFile)) {
+            if (!Zf::downloadZip($tmpFile, $version)) {
+                return $this->sendError (
+                    "I cannot download the ZF2 library from github."
+                );
+            }
+        }
+        
+        $zip = new \ZipArchive;
+        if ($zip->open($tmpFile)) { 
+            $zipFolder = $tmpDir . '/' . rtrim($zip->statIndex(0)['name'], "/"); 
+            if (!$zip->extractTo($tmpDir)) {
+                return $this->sendError("Error during the unzip of $tmpFile.");
+            }
+            
+            $result = Utility::copyFiles($zipFolder, $path);
+            if (file_exists($zipFolder)) {
+                Utility::deleteFolder($zipFolder);
+            }
+            $zip->close();
+            if (false === $result) {
+                return $this->sendError("Error during the copy of the files in $path.");
+            }
+        }
+        
+        $console->writeLine("The ZF library $version has been installed in $path.", Color::GREEN);
+    }
+       
+    /**
+     * Send an error message to the console
+     * 
+     * @param  string $msg
+     * @return ConsoleModel 
+     */
+    protected function sendError($msg)
+    {
+        $m = new ConsoleModel();
+        $m->setErrorLevel(2);
+        $m->setResult($msg . PHP_EOL);
+        return $m;
+    }
+}

--- a/src/ZFTool/Model/Skeleton.php
+++ b/src/ZFTool/Model/Skeleton.php
@@ -9,7 +9,6 @@ class Skeleton
     const SKELETON_URL    = 'https://github.com/zendframework/ZendSkeletonApplication/archive/master.zip';
     const API_LAST_COMMIT = 'https://api.github.com/repos/zendframework/ZendSkeletonApplication/commits?per_page=1';
     const SKELETON_FILE   = 'ZF2SA';
-    const SKELETON_DIR    = 'ZendSkeletonApplication-master';
     
     protected static $valueGenerator;
     
@@ -36,11 +35,10 @@ class Skeleton
     public static function getSkeletonApp($file)
     {
         $content = @file_get_contents(self::SKELETON_URL);
-        if (!empty($content)) {
-            file_put_contents($file, $content);
-            return true;
+        if (empty($content)) {
+            return false;
         }
-        return false;
+        return (file_put_contents($file, $content) !== false);
     }
     
     /**

--- a/src/ZFTool/Model/Zf.php
+++ b/src/ZFTool/Model/Zf.php
@@ -1,0 +1,88 @@
+<?php
+namespace ZFTool\Model;
+
+class Zf 
+{
+    
+    const LAST_VERSION    = 'http://framework.zend.com/api/zf-version?v=2';
+    const GET_TAGS        = 'https://api.github.com/repos/zendframework/zf2/tags';
+    const RELEASE_NAME    = 'release-';
+    
+    protected static $valueGenerator;
+    
+    protected static $tags = array();
+    
+    /**
+     * Get the last zf2 version available
+     * 
+     * @return string|boolean
+     */
+    public static function getLastVersion()
+    {
+        $content = @file_get_contents(self::LAST_VERSION);
+        if (!empty($content)) {
+            return $content;
+        }
+        return false;
+    }
+    
+    /**
+     * Check if a specified ZF version exists
+     * 
+     * @param  string $version
+     * @return boolean 
+     */
+    public static function checkVersion($version)
+    {
+        $tags = self::getTags();
+        return isset($tags[self::RELEASE_NAME . $version]);
+    }
+    
+    /**
+     * Get the tags of the ZF2 project
+     * 
+     * @return array 
+     */
+    public static function getTags()
+    {
+        if (empty(self::$tags)) {
+            $tags = json_decode(@file_get_contents(self::GET_TAGS), true);
+            foreach ($tags as $tag) {
+                self::$tags[$tag['name']] = $tag['zipball_url'];
+            }
+        }
+        return self::$tags;
+    }
+    
+    /**
+     * Download the ZF library in a zip file
+     * 
+     * @param  string $version
+     * @param  string $file
+     * @return boolean 
+     */
+    public static function downloadZip($file, $version)
+    {
+        $tags = self::getTags();
+        if (!isset($tags[self::RELEASE_NAME . $version])) {
+            return false;
+        }
+        $content = @file_get_contents($tags[self::RELEASE_NAME . $version]);
+        if (empty($content)) {
+            return false;
+        }
+       return (file_put_contents($file, $content) !== false);
+    }
+    
+    /**
+     * Get the temporary file name for the ZF2 library zip file
+     * 
+     * @param  string $tmpDir
+     * @param  string $version
+     * @return string 
+     */
+    public static function getTmpFileName($tmpDir, $version)
+    {
+        return "$tmpDir/ZF_$version.zip";
+    }
+}

--- a/src/ZFTool/Module.php
+++ b/src/ZFTool/Module.php
@@ -76,8 +76,12 @@ class Module implements ConsoleUsageProviderInterface, AutoloaderProviderInterfa
             array('<classmap file>',    'File name for generated class map file  or - for standard output.'.
                                         'If not supplied, defaults to autoload_classmap.php inside <directory>.'),
             array('--append | -a',      'Append to classmap file if it exists'),
-            array('--overwrite | -w',   'Whether or not to overwrite existing classmap file')
+            array('--overwrite | -w',   'Whether or not to overwrite existing classmap file'),
 
+            'Zend Framework 2 installation:',
+            'install zf <path> [<version>]' => '',
+            array('<path>', 'The directory where to install the ZF2 library'),
+            array('<version>', 'The version to install, if not specified uses the last available'),
         );
     }
 }


### PR DESCRIPTION
Added the possibility to install the ZF library in a specified path.
The command syntax is as follow:
zf.php install zf <path> [<version>]
The <version> can be one of the tags (only the numbers) in https://github.com/zendframework/zf2.
For instance for the tag 'release-2.0.6' the version number is '2.0.6'.
More information in the README.md file.
