### PR TITLE
php5.3.* compatibility

### DIFF
--- a/src/ZFTool/Controller/InstallController.php
+++ b/src/ZFTool/Controller/InstallController.php
@@ -55,7 +55,8 @@ class InstallController extends AbstractActionController
 
         $zip = new \ZipArchive;
         if ($zip->open($tmpFile)) {
-            $zipFolder = $tmpDir . '/' . rtrim($zip->statIndex(0)['name'], "/");
+            $zipFolders = $zip->statIndex(0);
+            $zipFolder = $tmpDir . '/' . rtrim($zipFolders['name'], "/");
             if (!$zip->extractTo($tmpDir)) {
                 return $this->sendError("Error during the unzip of $tmpFile.");
             }


### PR DESCRIPTION
line 58:
$zipFolder = $tmpDir . '/' . rtrim($zip->statIndex(0)['name'], "/");

replaced by :
$zipFolders = $zip->statIndex(0);
$zipFolder = $tmpDir . '/' . rtrim($zipFolders['name'], "/");

making "zf.php install zf anydir" working with php5.3.*
