### PR TITLE
Add requirement on OpenSSL extension for Project creation

### DIFF
--- a/src/ZFTool/Controller/CreateController.php
+++ b/src/ZFTool/Controller/CreateController.php
@@ -17,6 +17,9 @@ class CreateController extends AbstractActionController
         if (!extension_loaded('zip')) {
             return $this->sendError('You need to install the ZIP extension of PHP');
         }
+        if (!extension_loaded('openssl')) {
+            return $this->sendError('You need to install the OpenSSL extension of PHP');
+        }
         $console = $this->getServiceLocator()->get('console');
         $tmpDir  = sys_get_temp_dir();
         $request = $this->getRequest();


### PR DESCRIPTION
When OpenSSL extension isn't installed, the error message is "I cannot access the API of github." ... quite confusing.
@file_get_contents in Skeleton::getLastCommit() hides the error message on HTTPS.
