### PR TITLE
Fixing relative path of the target directory

### DIFF
--- a/src/ZFTool/Controller/ClassmapController.php
+++ b/src/ZFTool/Controller/ClassmapController.php
@@ -35,6 +35,8 @@ class ClassmapController extends AbstractActionController
             return $m;
         }
 
+        $directory = realpath($directory);
+
         // Determine output file name
         $output = $request->getParam('destination', $directory . '/autoload_classmap.php');
         if ('-' == $output) {


### PR DESCRIPTION
Wrong classmaps were generated because comparison between the classmap target file and the directory to be crawled were uncomparable
