### PR TITLE
Add User Agent as it is required by the github API

### DIFF
--- a/zf.php
+++ b/zf.php
@@ -9,6 +9,7 @@
  */
 error_reporting(E_ALL);
 ini_set("display_errors", 1);
+ini_set('user_agent', 'ZFTool - Zend Framework 2 command line tool');
 
 $basePath = __DIR__;
 if (file_exists("$basePath/vendor/autoload.php")) {
@@ -50,8 +51,5 @@ if (file_exists("$basePath/config/application.config.php")) {
         ),
     );
 }
-
-$version = Zend\Version\Version::VERSION;
-ini_set('user_agent', 'ZFTool/' .$version. ' (Zend Framework 2 command line Tool)');
 
 Zend\Mvc\Application::init($appConfig)->run();


### PR DESCRIPTION
See http://developer.github.com/v3/#user-agent-required for details:

This prevents us from the "I cannot access the API of github." error message. User Agent is required!

All API requests MUST include a valid User Agent string. Requests with no User Agent string will be rejected. If you are hitting the API without authentication, we ask that you add some kind of identification to the UA header value. This is so we can contact you if there are problems.
