### PR TITLE
Remove translator for preventing a crash

### DIFF
--- a/config/module.config.php
+++ b/config/module.config.php
@@ -6,12 +6,6 @@ return array(
 
     // -----=-----=-----=-----=-----=-----=-----=-----=-----=-----=-----=-----=-----=-----=-----=-----=
 
-    'service_manager' => array(
-        'factories' => array(
-            'translator' => 'Zend\I18n\Translator\TranslatorServiceFactory',
-        ),
-    ),
-
     'controllers' => array(
         'invokables' => array(
             'ZFTool\Controller\Info'        => 'ZFTool\Controller\InfoController',


### PR DESCRIPTION
The current Skeleton app have a translator aliases, so this part was conflicting and the application crashed. This solves the issue.
