### PR TITLE
Classmap : Fix double shash in filepaths, when using dot as directory

### DIFF
--- a/src/ZFTool/Controller/ClassmapController.php
+++ b/src/ZFTool/Controller/ClassmapController.php
@@ -66,7 +66,9 @@ class ClassmapController extends AbstractActionController
 
             // Simple case: $libraryPathCompare is in $classmapPathCompare
             if (strpos($directory, $classmapPath) === 0) {
-                $relativePath = substr($directory, strlen($classmapPath) + 1) . '/';
+                if($directory !== $classmapPath) { // prevent double dash in filepaths when using "." as directory
+                    $relativePath = substr($directory, strlen($classmapPath) + 1) . '/';
+                }
             } else {
                 $libraryPathParts  = explode('/', $directory);
                 $classmapPathParts = explode('/', $classmapPath);


### PR DESCRIPTION
https://github.com/zendframework/ZFTool/issues/29

This error occur only when using . as directory

```
zf classmap generate . autoload_classmap.php // double slash
```

```
zf classmap generate library autoload_classmap.php // no double slash
```
