### PR TITLE
Update CreateController.php

### DIFF
--- a/src/ZFTool/Controller/CreateController.php
+++ b/src/ZFTool/Controller/CreateController.php
@@ -176,7 +176,8 @@ class CreateController extends AbstractActionController
                 "The module $name already exists."
             );
         }
-
+        
+        $viewfolder = strtolower($name);
         $name = ucfirst($name);
         mkdir("$path/module/$name");
         mkdir("$path/module/$name/config");
@@ -184,6 +185,7 @@ class CreateController extends AbstractActionController
         mkdir("$path/module/$name/src/$name");
         mkdir("$path/module/$name/src/$name/Controller");
         mkdir("$path/module/$name/view");
+        mkdir("$path/module/$name/view/$viewfolder"); 
 
         // Create the Module.php
         file_put_contents("$path/module/$name/Module.php", Skeleton::getModule($name));


### PR DESCRIPTION
I Found A bug in ZfTool CLI module.
When we are using  zftool to create  module with  " ../zf.php  create module module-name [module path] " command and then after when we create a controller  with "   ../zf.php create controller User Sorry " . This  gives  error like this

PHP Warning:  mkdir(): No such file or directory in /../vendor/zendframework/zftool/src/ZFTool/Controller/CreateController.php on line 141
PHP Warning:  file_put_contents(./module/Sorry/view/sorry/user/index.phtml): failed to open stream: No such file or directory in /opt/lampp/htdocs/testzf23/vendor/zendframework/zftool/src/ZFTool/Controller/CreateController.php on line 146

while create a view index.phtml file. This is due to in previous create module command does not create a "module-namespace"  folder in src/view/ folder .
