### PR TITLE
Added batch file for windows. This file makes it possible for windows us...

### DIFF
--- a/zf2.bat
+++ b/zf2.bat
@@ -1,0 +1,2 @@
+@echo off
+php %~dp0zf.php %*


### PR DESCRIPTION
...ers to execute commands with "zf2" keyword, such as:

zf2 version
zf2 modules
  ..etc.

zf.php or zftool.phar are not executables in windows command prompt, so one cannot use them as direct commands and cannot make them globally available.
Dependencies:
php.exe environment variable
zf.php

This file uses "php" PATH environment variable and assumes that php has been registered as global command by adding php's directory to PATH environment variable. Failing this assumption should result in an error: php is not recognized as an internal or external command, operatable program or batch file.

Windows users can add the path of this file's directory to their PATH environment variable and use zf2 commands anywhere to create / maintain ZF2 projects.
