### PR TITLE
[WIP] Creation of factories for the service manager

### DIFF
--- a/config/module.config.php
+++ b/config/module.config.php
@@ -117,6 +117,15 @@ return array(
                         ),
                     ),
                 ),
+                'zftool-create-service-factory' => array(
+                    'options' => array(
+                        'route' => 'create service-factory <service> [<factory>] [<path>]',
+                        'defaults' => array(
+                            'controller' => 'ZFTool\Controller\Create',
+                            'action'     => 'service-factory'
+                        ),
+                    ),
+                ),
                 'zftool-install-zf' => array(
                     'options' => array(
                         'route'    => 'install zf <path> [<version>]',

--- a/src/ZFTool/Module.php
+++ b/src/ZFTool/Module.php
@@ -94,6 +94,13 @@ class Module implements ConsoleUsageProviderInterface, AutoloaderProviderInterfa
             array('<module>', 'The module containing the controller'),
             array('<path>', 'The root path of a ZF2 application where to create the action'),
 
+            'Service Factory creation:',
+            'create service-factory <service> [<factory>] [<path>]' => 'create a factory for a service',
+            array('<service>', 'The class for which a factory should be created.'),
+            array('<factory>', 'The class which should contain the factory. '
+                             . 'If not supplied, defaults to <service>Factory.'),
+            array('<path>', 'The root path of a ZF2 application where to create the factory.'),
+
             'Classmap generator:',
             'classmap generate <directory> <classmap file> [--append|-a] [--overwrite|-w]' => '',
             array('<directory>',        'The directory to scan for PHP classes (use "." to use current directory)'),


### PR DESCRIPTION
Allows to create factories for the service manager by using
`create service-factory <service> [<factory>] [<path>]`
- The factory class-name defaults to `<service>Factory`
- The constructor parameters will be fetched from the service manager by using the class-names as keys.
- Parameters without a type hint are set to `null`.
- `array` and `callable` are initialized to useless values (`array()` and `function () {}`).
- Optional parameters are not fetched.

The factory is not added to configuration yet. IMHO there should be support for the configuration of plugin managers besides the service manager (ControllerManager etc) should be also supported.

@RalfEggert This might be also interesting for #80.