### PR TITLE
preg_replace with modifier e is deprecated

### DIFF
--- a/src/ZFTool/Controller/ClassmapController.php
+++ b/src/ZFTool/Controller/ClassmapController.php
@@ -190,7 +190,7 @@ class ClassmapController extends AbstractActionController
         }
 
         $content = preg_replace_callback('(\n\s+([^=]+)=>)', function ($match) use ($maxWidth) {
-            return PHP_EOL . '    ' . $match[1] . str_repeat(' ', $maxWidth - strlen($match[1])) . '=>';
+            return "\n    " . $match[1] . str_repeat(' ', $maxWidth - strlen($match[1])) . '=>';
         }, $content);
 
         if (!$usingStdout) {


### PR DESCRIPTION
Hi,
during classmap generation an `E_DEPRECATED` warning was generated due to usage of `preg_replace` with modifier e.

I changed the according line in `ClassmapController` to use `preg_replace_callback`.

Best regards,
Matthias
