### PR TITLE
Wrong init_autoloader.php file name

### DIFF
--- a/zf.php
+++ b/zf.php
@@ -14,8 +14,8 @@ ini_set('user_agent', 'ZFTool - Zend Framework 2 command line tool');
 // load autoloader
 if (file_exists("$basePath/vendor/autoload.php")) {
     require_once "$basePath/vendor/autoload.php";
-} elseif (file_exists("$basePath/init_autoload.php")) {
-    require_once "$basePath/init_autoload.php";
+} elseif (file_exists("$basePath/init_autoloader.php")) {
+    require_once "$basePath/init_autoloader.php";
 } elseif (\Phar::running()) {
     require_once __DIR__ . '/vendor/autoload.php';
 } else {


### PR DESCRIPTION
May be i'm wrong, but without this ZFTool didn't work in project's created by ZFTool without copying in vendor directory